### PR TITLE
Allow string in return array key of matchAllPatterns

### DIFF
--- a/src/PlainString.php
+++ b/src/PlainString.php
@@ -247,7 +247,7 @@ final class PlainString implements StringValue
 
     /**
      * @param string|StringValue $pattern
-     * @return ArrayValue<array<int, string>>
+     * @return ArrayValue<array<int|string, string>>
      */
     public function matchAllPatterns($pattern): ArrayValue
     {

--- a/src/PlainStringsArray.php
+++ b/src/PlainStringsArray.php
@@ -498,7 +498,7 @@ final class PlainStringsArray implements StringsArray
 
     /**
      * @param string|StringValue $pattern
-     * @return ArrayValue<array<int, string>>
+     * @return ArrayValue<array<int|string, string>>
      */
     public function matchAllPatterns($pattern): ArrayValue
     {

--- a/src/StringValue.php
+++ b/src/StringValue.php
@@ -148,7 +148,7 @@ interface StringValue extends Value
 
     /**
      * @param string|StringValue $pattern
-     * @return ArrayValue<array<int, string>>
+     * @return ArrayValue<array<int|string, string>>
      */
     public function matchAllPatterns($pattern): ArrayValue;
 


### PR DESCRIPTION
If we use named capture groups, eg. `(?<surname>\w+)` it may have also string keys.